### PR TITLE
WIP to make AMQP EventSource work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # ko is (currently) incomptible with cgo, so the AMQP receive adapter is built via Docker.
 # ko uses a debian:stretch-slim
-FROM debian:stretch-slim as build_stage
+FROM debian:stretch-slim
+# AS build_stage
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
-RUN apt-get install -y cmake uuid-dev libssl-dev libsasl2-2 libsasl2-dev libsasl2-modules git gcc python-dev wget
+RUN apt-get install -y cmake uuid-dev libssl-dev libsasl2-2 libsasl2-dev libsasl2-modules git gcc python-dev wget libssl-dev libsasl2-2 libsasl2-modules
 RUN wget -q https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz && echo fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec go1.10.4.linux-amd64.tar.gz | sha256sum -c --quiet && tar -C /usr/local -xzf go1.10.4.linux-amd64.tar.gz && git clone git://git.apache.org/qpid-proton.git
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin
 ENV GOPATH=/qpid-proton/build/go CGO_CFLAGS=-I/qpid-proton/build/c/include CGO_LDFLAGS='-L/qpid-proton/build/c -lssl -lcrypto -lsasl2'
@@ -19,12 +20,14 @@ COPY pkg qpid-proton/build/go/src/github.com/knative/eventing-sources/pkg/
 RUN rm -f qpid-proton/build/go/pkg/linux_amd64/qpid.apache.org/*.a && rm -rf /root/.cache/go-build
 RUN cd qpid-proton/build/go/src/github.com/knative/eventing-sources/cmd/amqpsource && go install -x
 
+RUN mv /qpid-proton/build/go/bin/amqpsource /amqpsource
+
 # Insert here 2nd stage build step for thinner image.
 # Bonus points if can be done via a small increment to gcr.io/distroless/cc, i.e. sasl libs
-FROM debian:stretch-slim
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y \
-  libssl-dev libsasl2-2 libsasl2-modules \
-  && rm -rf /var/lib/apt/lists/*
-COPY --from=build_stage qpid-proton/build/go/bin/amqpsource /amqpsource
+# FROM debian:stretch-slim
+# ENV DEBIAN_FRONTEND noninteractive
+# RUN apt-get update && apt-get install -y \
+#   libssl-dev libsasl2-2 libsasl2-modules \
+#   && rm -rf /var/lib/apt/lists/*
+# COPY --from=build_stage qpid-proton/build/go/bin/amqpsource /amqpsource
 ENTRYPOINT ["/amqpsource"]

--- a/samples/01-channel.yaml
+++ b/samples/01-channel.yaml
@@ -1,0 +1,11 @@
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Channel
+metadata:
+  name: testchannel
+spec:
+  provisioner:
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: ClusterChannelProvisioner
+    name: in-memory-channel
+
+

--- a/samples/02-eventsource.yaml
+++ b/samples/02-eventsource.yaml
@@ -1,0 +1,14 @@
+apiVersion: sources.eventing.knative.dev/v1alpha1
+kind: ContainerSource
+metadata:
+ labels:
+   controller-tools.k8s.io: "1.0"
+ name: containersource-sample
+spec:
+ image: sjwoodman/amqp-adaptor:latest
+ args:
+  - '--amqpurl=amqp://artemis.myproject.svc.cluster.local:5672/knqueue'
+ sink:
+   apiVersion: eventing.knative.dev/v1alpha1
+   kind: Channel
+   name: testchannel

--- a/samples/03-service.yaml
+++ b/samples/03-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: message-dumper
+  namespace: myproject
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/eventing-sources/cmd/message_dumper

--- a/samples/04-subscription.yaml
+++ b/samples/04-subscription.yaml
@@ -1,0 +1,16 @@
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: testeventssubscription
+  namespace: myproject
+spec:
+  channel:
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: Channel
+    name: testchannel
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1alpha1
+      kind: Service
+      name: message-dumper
+


### PR DESCRIPTION
*DO NOT MERGE*

I think I've managed to get the AMQP EventSouce to work. Some notes/comments.

In the logs I see some empty CloudEvents so I assume there are some empty AMQP messages being delivered.

```
$ oc logs message-dumper-00001-deployment-84fb6985-4l76j -c user-container -f
2018/11/27 12:39:11 Message Dumper received a message: POST / HTTP/1.1
Host: message-dumper.myproject.svc.cluster.local
Accept-Encoding: gzip
Ce-Cloudeventsversion: 0.1
Ce-Eventid: 11
Ce-Eventtime: 2018-11-27T12:39:11.286081311Z
Ce-Eventtype: amqp.delivery
Ce-Source: some_canon_amqpaddr_rep_TODO
Content-Length: 2
Content-Type: application/json
User-Agent: Go-http-client/1.1
X-B3-Parentspanid: a01f00e8958b26fa
X-B3-Sampled: 1
X-B3-Spanid: 3bb2bff992beb6d9
X-B3-Traceid: a01f00e8958b26fa
X-Forwarded-For: 127.0.0.1
X-Forwarded-Proto: http
X-Request-Id: c46f4a11-5cf2-9712-b6b1-6da428aba115

{}
```

* I had to edit the Dockerfile as Docker in my minishift is not new enough to support Staged Builds and I'm not sure how to update it. You probably don't want to merge this...
* I had to push the `adaptor` image to DockerHub to get it to deploy. I'm not sure why but simply tagging it locally didn't want to work. I suspect the `ContainerSource` may have a property of `ImagePullPolicy: Always` which will only work, I think, with images in a remote repo.
*  I used the https://github.com/vromero/activemq-artemis-docker container as a Broker as it was easier to setup than AMQ Broker (from the instructions I found). `oc new-app --name=artemis vromero/activemq-artemis -e RESTORE_CONFIGURATION=true`
* I didn't actually send any AMQP messages but given the logs I think it's working
* The issue was with the address of the Broker so I changed it to the structure that has worked for Kafka which is the fully-qualified service name
* There are sample files in `/samples' which I used with `oc apply -f` to bring everything up